### PR TITLE
Mount local aprexis-engine dir in platform and api docker-compose

### DIFF
--- a/docker-compose-api.yml
+++ b/docker-compose-api.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
       - ./aprexis-data:/aprexis-data
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-platform.sh; rm -f tmp/pids/server.pid && bundle exec puma -b tcp://0.0.0.0:3000"
     ports:
       - "${APREXIS_PLATFORM_PORT}:3000"
@@ -48,6 +49,7 @@ services:
     volumes:
       - ./aprexis-api:/aprexis-api
       - ./aprexis-platform-5/storage:/aprexis-api/storage
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-rails.sh; rm -f tmp/pids/server.pid && bundle exec puma -b tcp://0.0.0.0:3250"
     ports:
       - "${APREXIS_API_PORT}:3250"
@@ -80,6 +82,7 @@ services:
       - redis
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-platform.sh; bundle exec rails resque:work QUEUE=*"
     ports: []
     extra_hosts:
@@ -92,6 +95,7 @@ services:
       - redis
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-platform.sh; bundle exec rails resque:scheduler"
     ports: []
     extra_hosts:

--- a/docker-compose-platform.yml
+++ b/docker-compose-platform.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
       - ./aprexis-data:/aprexis-data
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-rails.sh; rm -f tmp/pids/server.pid && bundle exec puma -b tcp://0.0.0.0:3000"
     ports:
       - "${APREXIS_PLATFORM_PORT}:3000"
@@ -44,6 +45,7 @@ services:
       - redis
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-rails.sh; bundle exec rails resque:work QUEUE=*"
     ports: []
     extra_hosts:
@@ -56,6 +58,7 @@ services:
       - redis
     volumes:
       - ./aprexis-platform-5:/aprexis-platform-5
+      - ./aprexis-engine:/aprexis-engine
     command: bash --login -c "/aprexis/setup-for-rails.sh; bundle exec rails resque:scheduler"
     ports: []
     extra_hosts:


### PR DESCRIPTION
This change makes it so that when a dev working on platform or api code also needs to modify code in aprexis-engine, they do not need to rebuild the docker containers. Instead they can just restart the stack.