### PR TITLE
add a "make git_pull" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ postgres:
 redis:
 	${DIR}/export-env.sh; export APREXIS_VARIETY=${APREXIS_VARIETY}; ${DIR}/upd.sh redis
 
+git_pull:
+	${DIR}/export-env.sh; export APREXIS_VARIETY=${APREXIS_VARIETY}; ${DIR}/git_pull.sh
+
 
 stop_android:
 	adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done

--- a/README.md
+++ b/README.md
@@ -320,6 +320,16 @@ make platform_shell # (to test the original Rails platform)
 make api_shell # (to test the API)
 ```
 
+## Pull all latest code
+
+Issues a `git pull` on all of the aprexis-* repositories used by docker-compose. This will pull whatever branch is currently checked out locally for each repository.
+
+If the the branch has local changes, those changes are stashed to avoid potential conflicts. Any stashed changes will need to be unstashed manually.
+
+```bash
+make git_pull
+```
+
 ## Running the system in a hybrid fashion
 
 You can use docker to provide Postgres, Redis, and optionally SOLR. If you've done a build of the system, there are four useful Make commands available:

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ make api_shell # (to test the API)
 
 Issues a `git pull` on all of the aprexis-* repositories used by docker-compose. This will pull whatever branch is currently checked out locally for each repository.
 
-If the the branch has local changes, those changes are stashed to avoid potential conflicts. Any stashed changes will need to be unstashed manually.
+If the branch has local changes, those changes are stashed to avoid potential conflicts. Any stashed changes will need to be unstashed manually.
 
 ```bash
 make git_pull

--- a/git_pull.sh
+++ b/git_pull.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Performs a git pull on all of the sub repositories that are checked out. If the repository has local changes, those changes are stashed before the pull.
+
+DIR=$(dirname "$0")
+
+do_git_pull () {
+  GIT_DIR=$1
+  cd $DIR/$GIT_DIR
+  GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  echo "-------"
+  if [[ `git status --porcelain` ]]; then
+    echo "warning: stashing local changes on $GIT_DIR $GIT_BRANCH ..."
+    git stash
+  fi
+  echo "pulling $GIT_DIR $GIT_BRANCH ..."
+  git pull
+}
+
+if [ -d "$DIR/aprexis-api" ]; then
+  do_git_pull "aprexis-api"
+fi
+
+if [ -d "$DIR/aprexis-api-ui" ]; then
+  do_git_pull "aprexis-api-ui"
+fi
+
+if [ -d "$DIR/aprexis-engine" ]; then
+  do_git_pull "aprexis-engine"
+fi
+
+if [ -d "$DIR/aprexis-platform-5" ]; then
+  do_git_pull "aprexis-platform-5"
+fi
+
+if [ -d "$DIR/aprexis-etl" ]; then
+  do_git_pull "aprexis-etl"
+fi
+
+cd $DIR


### PR DESCRIPTION
Adds a `make git_pull` task that issues a git pull for all of these repos, if they exist in the dev environment:
- aprexis-api
- aprexis-api-ui
- aprexis-platform-5
- aprexis-engine
- aprexis-etl