### PR TITLE
Update bundle install step

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -24,7 +24,7 @@ RUN cp /etc/hosts /tmp/hosts.original && sed -e 's/localhost ip6-localhost/ip6-l
 WORKDIR /aprexis-api
 COPY ./aprexis-api/Gemfile ./aprexis-api/Gemfile.lock ./
 RUN env
-RUN bundle config --local GITHUB__COM x-access-token:${APREXIS_ENGINE_TOKEN} && bundle install
+RUN bundle config --local GITHUB__COM x-access-token:${APREXIS_ENGINE_TOKEN}
 
 # Install the application
 ADD ./aprexis-api /aprexis-api

--- a/Dockerfile-engine
+++ b/Dockerfile-engine
@@ -19,7 +19,6 @@ WORKDIR /aprexis-engine
 RUN mkdir -p /aprexis-engine/lib/aprexis/engine
 COPY ./aprexis-engine/lib/aprexis/engine/version.rb /aprexis-engine/lib/aprexis/engine
 COPY ./aprexis-engine/Gemfile ./aprexis-engine/aprexis-engine.gemspec ./aprexis-engine/Gemfile.lock ./
-RUN bundle install
 
 # Install the application
 ADD ./aprexis-engine /aprexis-engine

--- a/Dockerfile-etl
+++ b/Dockerfile-etl
@@ -27,7 +27,6 @@ RUN cp /etc/hosts /tmp/hosts.original && sed -e 's/localhost ip6-localhost/ip6-l
 
 WORKDIR /aprexis-etl
 COPY ./aprexis-etl/Gemfile ./aprexis-etl/Gemfile.lock ./
-RUN bundle install
 
 # Install the application
 ADD ./aprexis-etl /aprexis-etl

--- a/Dockerfile-platform
+++ b/Dockerfile-platform
@@ -53,7 +53,7 @@ RUN cp /etc/hosts /tmp/hosts.original && sed -e 's/localhost ip6-localhost/ip6-l
 WORKDIR /aprexis-platform-5
 COPY ./aprexis-platform-5/Gemfile ./aprexis-platform-5/Gemfile.lock ./aprexis-platform-5/package.json ./
 RUN git config --global --add safe.directory /aprexis-platform-5 && \
-    bundle config --local GITHUB__COM x-access-token:${APREXIS_ENGINE_TOKEN} && bundle install
+    bundle config --local GITHUB__COM x-access-token:${APREXIS_ENGINE_TOKEN}
 
 # Install the application
 ADD ./aprexis-platform-5 /aprexis-platform-5

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ build_platform:
 
 bundle_install:
 	docker-compose -f docker-compose-api.yml run --rm platform bundle install
+	docker-compose -f docker-compose-api.yml run --rm api bundle install
+	docker-compose -f docker-compose-etl.yml run --rm etl bundle install
+	docker-compose -f docker-compose-engine.yml run --rm engine bundle install
 
 clean_docker:
 	export APREXIS_VARIETY=${APREXIS_VARIETY}; ${DIR}/clean_docker.sh

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ build_etl:
 build_platform:
 	${DIR}/export-env.sh; export APREXIS_VARIETY=platform; ${DIR}/build.sh
 
+bundle_install:
+	docker-compose -f docker-compose-api.yml run --rm platform bundle install
+
 clean_docker:
 	export APREXIS_VARIETY=${APREXIS_VARIETY}; ${DIR}/clean_docker.sh
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To build it from the new-style anonymized data, run:
 make build_engine
 make load_anonymized_db
 make build
+make bundle_install
 make up
 ```
 
@@ -76,6 +77,7 @@ To build it from the old-style full database dump anonymized data, run:
 make build_engine
 make new_db
 make build
+make bundle_install
 make up
 ```
 

--- a/env.example
+++ b/env.example
@@ -1,4 +1,6 @@
-# Default environment values for Aprexis docker project.
+########################################################################################
+############### Default environment values for Aprexis docker project. #################
+########################################################################################
 
 # Host IP address for development docker
 APREXIS_HOST_IP=172.17.0.1
@@ -28,3 +30,14 @@ APREXIS_REDIS_TEST_SESSION_URL=redis://redis:6379/2
 # Aprexis Engine
 APREXIS_USERNAME=<your Github username>
 APREXIS_ENGINE_TOKEN=<your Github fine-grained access token for the Aprexis engine>
+
+########################################################################################
+############# Environment variables for all environments. ##############################
+########################################################################################
+
+SERVER_HOST=localhost:3000
+
+SECRET_KEY_BASE=82d7b3a4ecff2efd26d2b13d33957a2225a961b6336d31cf7bb5e2eb0911b251cdbaea1fe202f9d49b72f043f25baa1b1c0ac276b596be1d3e6502774c76704a
+
+# Devise encryption key. Must be 32 chars or more
+DEVISE_ENCRYPTION_KEY=kdhfuyeodndjskdjeitofmmkcvpdjehtkr

--- a/env.example
+++ b/env.example
@@ -1,6 +1,4 @@
-########################################################################################
-############### Default environment values for Aprexis docker project. #################
-########################################################################################
+# Default environment values for Aprexis docker project.
 
 # Host IP address for development docker
 APREXIS_HOST_IP=172.17.0.1
@@ -30,14 +28,3 @@ APREXIS_REDIS_TEST_SESSION_URL=redis://redis:6379/2
 # Aprexis Engine
 APREXIS_USERNAME=<your Github username>
 APREXIS_ENGINE_TOKEN=<your Github fine-grained access token for the Aprexis engine>
-
-########################################################################################
-############# Environment variables for all environments. ##############################
-########################################################################################
-
-SERVER_HOST=localhost:3000
-
-SECRET_KEY_BASE=82d7b3a4ecff2efd26d2b13d33957a2225a961b6336d31cf7bb5e2eb0911b251cdbaea1fe202f9d49b72f043f25baa1b1c0ac276b596be1d3e6502774c76704a
-
-# Devise encryption key. Must be 32 chars or more
-DEVISE_ENCRYPTION_KEY=kdhfuyeodndjskdjeitofmmkcvpdjehtkr


### PR DESCRIPTION
Since gems are now stored in a docker volume that is shared by all containers, gems should be installed and managed by docker-compose rather than during the image build process. 

- Removes `bundle install` from Docker files
- Adds a `make bundle_install` command
- Updates the README